### PR TITLE
[スキーマ案1] assigneeをorderが持つ

### DIFF
--- a/app/models/order.ts
+++ b/app/models/order.ts
@@ -8,7 +8,7 @@ export const orderSchema = z.object({
   createdAt: z.date(),
   servedAt: z.date().nullable(),
   items: z.array(itemSchema.required()),
-  assignee: z.string().nullable(),
+  assignee: z.array(z.string().nullable()),
   total: z.number(),
   orderReady: z.boolean(),
 });
@@ -23,7 +23,7 @@ export class OrderEntity implements Order {
     private readonly _createdAt: Date,
     private _servedAt: Date | null,
     private _items: WithId<ItemEntity>[],
-    private _assignee: string | null,
+    private _assignee: (string | null)[],
     private _total: number,
     private _orderReady: boolean,
   ) {}
@@ -35,7 +35,7 @@ export class OrderEntity implements Order {
       new Date(),
       null,
       [],
-      null,
+      [],
       0,
       false,
     );
@@ -84,7 +84,7 @@ export class OrderEntity implements Order {
   get assignee() {
     return this._assignee;
   }
-  set assignee(assignee: string | null) {
+  set assignee(assignee: (string | null)[]) {
     this._assignee = assignee;
   }
 


### PR DESCRIPTION
# カップ別指名を実現するためのスキーマ変更案１

orderのitemsとindexが一致するようにassignee配列を持つ

下記の例では
- ひんやりだいだいを"3"番ドリッパー
- だいだいオレをてけとさん

が担当することを示している。

```jsonc
{
  id: "...",
  orderId: 104,
  createdAt: ...,
  servedAt: null,
  items: [
    {
      id: "...",
      name: "だいだいブレンド",
      price: 300,
      type: "hot"
    },
    {
      id: "...",
      name: "ひんやりだいだい",
      price: 300,
      type: "ice"
    },
    {
      id: "...",
      name: "だいだいオレ",
      price: 400,
      type: "ore"
    }
  ],
  assignee: [null, "3", "てけと"],
  total: 1000,
  orderReady: false
}
```

## メリット
- item に不要な情報を持たせなくてよい

## デメリット
- index がズレる実装ミスをしたときに怖い
