### PR TITLE
[スキーマ案2] assignee を item が持つ

### DIFF
--- a/app/models/item.ts
+++ b/app/models/item.ts
@@ -11,6 +11,7 @@ export const itemSchema = z.object({
     required_error: "種類が未選択です",
     invalid_type_error: "不正な種類です",
   }),
+  assignee: z.string().nullable(),
 });
 
 export type Item = z.infer<typeof itemSchema>;
@@ -33,10 +34,11 @@ export class ItemEntity implements Item {
     public readonly name: string,
     public readonly price: number,
     public readonly type: ItemType,
+    public assignee: string | null = null,
   ) {}
 
   static createNew({ name, price, type }: Item): ItemEntity {
-    return new ItemEntity(undefined, name, price, type);
+    return new ItemEntity(undefined, name, price, type, null);
   }
 
   static fromItem(item: WithId<Item>): WithId<ItemEntity> {


### PR DESCRIPTION
# カップ別指名を実現するためのスキーマ変更案２

orderの中に含まれる個々のitemがassigneeプロパティを持つ

下記の例では
- ひんやりだいだいを"3"番ドリッパー
- だいだいオレをてけとさん

が担当することを示している。

```jsonc
{
  id: "...",
  orderId: 104,
  createdAt: ...,
  servedAt: null,
  items: [
    {
      id: "...",
      name: "だいだいブレンド",
      price: 300,
      type: "hot",
      assignee: null
    },
    {
      id: "...",
      name: "ひんやりだいだい",
      price: 300,
      type: "ice",
      assignee: "3"
    },
    {
      id: "...",
      name: "だいだいオレ",
      price: 400,
      type: "ore",
      assignee: "てけと"
    }
  ],
  total: 1000,
  orderReady: false
}
```