### PR TITLE
OrderEntityの備考欄も自動で空文字列をnullに変換する

### DIFF
--- a/common/models/order.ts
+++ b/common/models/order.ts
@@ -132,7 +132,11 @@ export class OrderEntity implements Order {
     return this._description;
   }
   set description(description: string | null) {
-    this._description = description;
+    if (description === "") {
+      this._description = null;
+    } else {
+      this._description = description;
+    }
   }
 
   get billingAmount() {


### PR DESCRIPTION
fix: #275