### PR TITLE
同期テキストのauthor略称変更

### DIFF
--- a/pos/app/routes/_header.master.tsx
+++ b/pos/app/routes/_header.master.tsx
@@ -110,7 +110,13 @@ export default function FielsOfMaster() {
                             key={`${index}-${comment.author}`}
                             className="my-2 flex rounded-md bg-gray-200 px-2 py-1"
                           >
-                            <div className="flex-none">{comment.author}：</div>
+                            <div className="flex-none">
+                              {(comment.author === "cashier" && "レジ") ||
+                                (comment.author === "master" && "マス") ||
+                                (comment.author === "serve" && "サー") ||
+                                (comment.author === "others" && "他")}
+                              ：
+                            </div>
                             <div>{comment.text}</div>
                           </div>
                         ))}

--- a/pos/app/routes/_header.master.tsx
+++ b/pos/app/routes/_header.master.tsx
@@ -108,14 +108,13 @@ export default function FielsOfMaster() {
                         {order.comments.map((comment, index) => (
                           <div
                             key={`${index}-${comment.author}`}
-                            className="my-2 flex rounded-md bg-gray-200 px-2 py-1"
+                            className="my-2 flex gap-2 rounded-md bg-gray-200 px-2 py-1"
                           >
-                            <div className="flex-none">
-                              {(comment.author === "cashier" && "レジ") ||
-                                (comment.author === "master" && "マス") ||
-                                (comment.author === "serve" && "サー") ||
+                            <div className="flex-none font-bold">
+                              {(comment.author === "cashier" && "レ") ||
+                                (comment.author === "master" && "マ") ||
+                                (comment.author === "serve" && "提") ||
                                 (comment.author === "others" && "他")}
-                              ：
                             </div>
                             <div>{comment.text}</div>
                           </div>

--- a/pos/app/routes/_header.serve.tsx
+++ b/pos/app/routes/_header.serve.tsx
@@ -135,14 +135,13 @@ export default function Serve() {
                         {order.comments.map((comment, index) => (
                           <div
                             key={`${index}-${comment.author}`}
-                            className="my-2 flex rounded-md bg-gray-200 px-2 py-1"
+                            className="my-2 flex gap-2 rounded-md bg-gray-200 px-2 py-1"
                           >
-                            <div className="flex-none">
-                              {(comment.author === "cashier" && "レジ") ||
-                                (comment.author === "master" && "マス") ||
-                                (comment.author === "serve" && "サー") ||
+                            <div className="flex-none font-bold">
+                              {(comment.author === "cashier" && "レ") ||
+                                (comment.author === "master" && "マ") ||
+                                (comment.author === "serve" && "提") ||
                                 (comment.author === "others" && "他")}
-                              ：
                             </div>
                             <div>{comment.text}</div>
                           </div>

--- a/pos/app/routes/_header.serve.tsx
+++ b/pos/app/routes/_header.serve.tsx
@@ -137,7 +137,13 @@ export default function Serve() {
                             key={`${index}-${comment.author}`}
                             className="my-2 flex rounded-md bg-gray-200 px-2 py-1"
                           >
-                            <div className="flex-none">{comment.author}：</div>
+                            <div className="flex-none">
+                              {(comment.author === "cashier" && "レジ") ||
+                                (comment.author === "master" && "マス") ||
+                                (comment.author === "serve" && "サー") ||
+                                (comment.author === "others" && "他")}
+                              ：
+                            </div>
                             <div>{comment.text}</div>
                           </div>
                         ))}


### PR DESCRIPTION
#329 
- `cashier`: `レ`
- `master`: `マ`
- `serve`: `提`