### PR TITLE
feat: 注文分割推奨の表示機能を追加

### DIFF
--- a/modules/common/src/models/index.ts
+++ b/modules/common/src/models/index.ts
@@ -1,3 +1,4 @@
 export * from "./global";
 export * from "./item";
 export * from "./order";
+export * from "./recommendation";

--- a/modules/common/src/models/recommendation.ts
+++ b/modules/common/src/models/recommendation.ts
@@ -1,0 +1,39 @@
+import { ITEM_MASTER } from "../data/items";
+import type { WithId } from "../lib/typeguard";
+import type { ItemEntity } from "./item";
+
+/**
+ * ドリッパーを3人以上確保する注文かどうかを判定する
+ * 条件：
+ * - トートセットは縁ブレンドとして扱う
+ * - コーヒーの種類が1種類なら4杯までならtrue、5杯以上ならfalse
+ * - コーヒーの種類が2種類なら、1種類につき2杯までならtrue、3杯以上のものが1種類でもあればfalse
+ * @param items 注文アイテムの配列
+ * @returns 分割が必要かどうかのboolean値
+ */
+export function shouldSplitOrder(items: WithId<ItemEntity>[]): boolean {
+  const yushoId = ITEM_MASTER["-"].id;
+  const toteSetsId = ITEM_MASTER["@"].id;
+
+  // トートセットを縁ブレンドとして扱い、種類別にカウント
+  const coffeeCounts = new Map<string, number>();
+
+  for (const item of items) {
+    if (item.type !== "milk" && item.type !== "others") {
+      // 通常のコーヒー
+      coffeeCounts.set(item.id, (coffeeCounts.get(item.id) || 0) + 1);
+    } else if (item.id === toteSetsId) {
+      // トートセットは縁ブレンドとして扱う
+      coffeeCounts.set(yushoId, (coffeeCounts.get(yushoId) || 0) + 1);
+    }
+  }
+
+  const types = coffeeCounts.size;
+  const counts = Array.from(coffeeCounts.values());
+
+  return (
+    types >= 3 ||
+    (types === 2 && counts.some((count) => count >= 3)) ||
+    (types === 1 && counts[0] >= 5)
+  );
+}

--- a/services/pos/app/components/organisms/SubmitSection.tsx
+++ b/services/pos/app/components/organisms/SubmitSection.tsx
@@ -1,4 +1,5 @@
 import type { OrderEntity } from "@cafeore/common";
+import { shouldSplitOrder } from "@cafeore/common";
 import { useEffect, useMemo, useRef } from "react";
 import { Button } from "../ui/button";
 
@@ -13,6 +14,11 @@ export const SubmitSection = ({ submitOrder, order, focus }: props) => {
   const billingOk = useMemo(
     () => order.items.length > 0 && order.getCharge() >= 0,
     [order],
+  );
+
+  const needsSplit = useMemo(
+    () => shouldSplitOrder(order.items),
+    [order.items],
   );
 
   /**
@@ -40,6 +46,11 @@ export const SubmitSection = ({ submitOrder, order, focus }: props) => {
         <label htmlFor="submit-button" className="text-sm text-stone-400">
           赤枠が出ている状態で Enter で送信
         </label>
+        {needsSplit && (
+          <p className="text-red-500 font-bold text-center">
+            この注文の分割を推奨します
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
- shouldSplitOrder関数を実装し、ドリッパー3人以上が必要な注文を判定
- 送信ボタン下に赤文字で「この注文の分割を推奨します」を表示
- トートセットは縁ブレンドとして扱う
- 条件: 1種類5杯以上、2種類で1種類あたり3杯以上、3種類以上

close #525 