### PR TITLE
Cashier mini画面のグラデーション背景とドロップシャドウ調整

### DIFF
--- a/services/pos/app/routes/cashier-mini.tsx
+++ b/services/pos/app/routes/cashier-mini.tsx
@@ -85,7 +85,7 @@ export default function CasherMini() {
 
   const charge = useMemo(() => order?.getCharge() ?? 0, [order]);
   const textShadowStyle = useMemo(
-    () => ({ textShadow: "0 8px 18px rgba(0, 0, 0, 0.45)" }),
+    () => ({ textShadow: "0 10px 28px rgba(0, 0, 0, 0.6)" }),
     [],
   );
 


### PR DESCRIPTION
概要
cashier-mini.tsx の背景を呼び出し画面と同じグラデーションに統一。
各テキストにドロップシャドウを付与し、視認性を向上。
ドロップシャドウをさらに強めて立体感を調整。
変更内容
背景クラスを bg-gradient-to-br from-theme2025 via-teal-600 to-theme2025 に変更。
共通 textShadowStyle を追加し、注文番号や明細などの文字へ適用。
シャドウ値を 0 10px 28px rgba(0, 0, 0, 0.6) に調整。
動作確認
pnpm run fmt（pre-commit フック経由）