### PR TITLE
feat(pos): オフライン時の手動採番と注文番号表示UIを追加

### DIFF
--- a/services/pos/app/components/functional/useLatestOrderId.ts
+++ b/services/pos/app/components/functional/useLatestOrderId.ts
@@ -28,45 +28,35 @@ const calcCannotAutoAssignOrderId = (
 const useOrderIdOverride = () => {
   const [manualOrderId, setManualOrderId] = useState<number | null>(null);
 
-  // 手動で番号を設定する（オフライン時に使用）
+  // 手動で番号を設定する（null で自動モードに戻す）
   const setOrderIdOverride = useCallback((orderId: number | null) => {
     setManualOrderId(orderId);
   }, []);
 
-  // 手動設定をクリアして自動モードに戻す
-  const clearOrderIdOverride = useCallback(() => {
-    setManualOrderId(null);
-  }, []);
-
-  return { manualOrderId, setOrderIdOverride, clearOrderIdOverride };
+  return { manualOrderId, setOrderIdOverride };
 };
 
 /**
  * オーダーのIDの最大値と次のIDを取得する
  * @param orders オーダーのリスト
- * @returns オーダーIDの最大値と次のID、および手動オーバーライド用の関数
+ * @returns 次のID、手動採番要否、手動指定値、およびオーバーライド用の setter（null で自動に戻す）
  */
 const useLatestOrderId = (orders: WithId<OrderEntity>[] | undefined) => {
   const isNetworkOnline = useOnlineStatus();
-  const { manualOrderId, setOrderIdOverride, clearOrderIdOverride } =
-    useOrderIdOverride();
+  const { manualOrderId, setOrderIdOverride } = useOrderIdOverride();
 
   const latestOrderId = useMemo(() => calcLatestOrderId(orders), [orders]);
-  // 手動指定がなければ自動採番（最大ID + 1）を使用
-  const autoNextOrderId = latestOrderId + 1;
-  const nextOrderId = manualOrderId ?? autoNextOrderId;
+  const nextOrderId = manualOrderId ?? latestOrderId + 1;
   const isNeedManualOrderId = calcCannotAutoAssignOrderId(
     isNetworkOnline,
     orders,
   );
 
   return {
-    latestOrderId,
     nextOrderId,
     isNeedManualOrderId,
     manualOrderId,
     setOrderIdOverride,
-    clearOrderIdOverride,
   };
 };
 

--- a/services/pos/app/components/molecules/OrderIdDisplay.tsx
+++ b/services/pos/app/components/molecules/OrderIdDisplay.tsx
@@ -7,7 +7,6 @@ type Props = {
   isNeedManualOrderId: boolean;
   manualOrderId: number | null;
   onOrderIdOverride: (orderId: number | null) => void;
-  onClearOverride: () => void;
 };
 
 /**
@@ -19,18 +18,18 @@ const OrderIdDisplay = ({
   isNeedManualOrderId,
   manualOrderId,
   onOrderIdOverride,
-  onClearOverride,
 }: Props) => {
   const [isEditingOrderId, setIsEditingOrderId] = useState(false);
   const [orderIdInputValue, setOrderIdInputValue] = useState("");
   const orderIdInputRef = useFocusRef<HTMLInputElement>(isEditingOrderId);
+  const isEditable = isNeedManualOrderId || manualOrderId !== null;
 
   const handleOrderIdClick = useCallback(() => {
-    if (isNeedManualOrderId || manualOrderId !== null) {
+    if (isEditable) {
       setIsEditingOrderId(true);
       setOrderIdInputValue(orderId.toString());
     }
-  }, [isNeedManualOrderId, manualOrderId, orderId]);
+  }, [isEditable, orderId]);
 
   const handleOrderIdChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -86,15 +85,15 @@ const OrderIdDisplay = ({
           onClick={handleOrderIdClick}
           className={cn(
             "font-extrabold text-3xl",
-            (isNeedManualOrderId || manualOrderId !== null) &&
+            isEditable &&
               "cursor-pointer underline decoration-dotted hover:text-theme",
           )}
           title={
-            isNeedManualOrderId
-              ? "オフラインモード: クリックして番号を指定"
-              : manualOrderId !== null
-                ? "番号を手動指定中: クリックして変更"
-                : undefined
+            isEditable
+              ? isNeedManualOrderId
+                ? "オフラインモード: クリックして番号を指定"
+                : "番号を手動指定中: クリックして変更"
+              : undefined
           }
         >
           No.{orderId}
@@ -108,7 +107,7 @@ const OrderIdDisplay = ({
       {manualOrderId !== null && (
         <button
           type="button"
-          onClick={onClearOverride}
+          onClick={() => onOrderIdOverride(null)}
           className="rounded bg-gray-400 px-2 py-1 text-sm text-white hover:bg-gray-500"
         >
           自動に戻す

--- a/services/pos/app/components/pages/CashierV2.tsx
+++ b/services/pos/app/components/pages/CashierV2.tsx
@@ -60,7 +60,6 @@ const CashierV2 = ({ items, orders, submitPayload, syncOrder }: props) => {
     isNeedManualOrderId,
     manualOrderId,
     setOrderIdOverride,
-    clearOrderIdOverride,
   } = useLatestOrderId(orders);
   const soundRef = useRef<HTMLAudioElement>(null);
   const submit = useSubmit();
@@ -194,7 +193,6 @@ const CashierV2 = ({ items, orders, submitPayload, syncOrder }: props) => {
             isNeedManualOrderId={isNeedManualOrderId}
             manualOrderId={manualOrderId}
             onOrderIdOverride={setOrderIdOverride}
-            onClearOverride={clearOrderIdOverride}
           />
           <div className="flex items-center space-x-2">
             <Switch


### PR DESCRIPTION
# オフライン時の手動採番と注文番号表示UIの追加

## 概要
オフライン時や注文一覧が取得できない場合に、注文番号を手動で指定・編集できるようにしました。キャッシャー画面の注文番号表示をコンポーネント化し、手動採番時はクリックで番号を変更できるUIを追加しています。

Closes #650

## 変更内容

### useLatestOrderId.ts
- **オフライン判定**: `useOnlineStatus` を利用し、ネットワークオフライン時は手動採番が必要と判定
- **手動オーバーライド**: `useOrderIdOverride` で手動番号の状態と `setOrderIdOverride` を提供（`setOrderIdOverride(null)` で自動モードに戻す）
- **純粋関数の分離**: `calcLatestOrderId`（最大 orderId 算出）、`calcCannotAutoAssignOrderId`（手動採番要否）を切り出し
- **戻り値**: `nextOrderId`、`isNeedManualOrderId`、`manualOrderId`、`setOrderIdOverride`

### OrderIdDisplay.tsx（新規）
- 注文番号の表示・編集用コンポーネント
- Props: `orderId`、`isNeedManualOrderId`、`manualOrderId`、`onOrderIdOverride`（`null` で自動に戻す）
- 手動採番が必要なとき、または手動指定中はクリックで編集モードにし、番号を入力可能（`isEditable` で条件を集約）
- Blur / Enter で確定、Escape でキャンセル。確定時は整数かつ正の値のみ受け付け（`"12abc"` などは弾く）
- 「オフライン」バッジと「自動に戻す」ボタン（`onOrderIdOverride(null)` を呼ぶ）を表示

### CashierV2.tsx
- 注文番号表示を `OrderIdDisplay` に差し替え
- `useLatestOrderId` の戻り値（`nextOrderId`、`isNeedManualOrderId`、`manualOrderId`、`setOrderIdOverride`）を利用
- 送信後に手動採番中だった場合は、次の番号を `setOrderIdOverride(manualOrderId + 1)` で自動設定

## 動作
- **オンライン・orders あり**: 従来どおり自動採番。注文番号は編集不可（クリック不可）。
- **オフライン or orders なし/空**: 「オフライン」表示。注文番号をクリックして手動入力可能。「自動に戻す」でオンライン復帰後に自動採番に戻せる。
- **手動で番号入力 → 送信**: 次回表示の注文番号は「入力した番号 + 1」になる。

## テスト
- [x] オンライン時: 注文番号が自動採番され、クリックで編集できないこと
- [x] オフライン時: 「オフライン」表示が出て、注文番号をクリックして手動入力できること
- [x] 手動で番号を入力して確定後、送信すると次の注文番号が「入力値 + 1」になること
- [x] 「自動に戻す」で手動指定が解除され、自動採番に戻ること
- [x] 編集で「12abc」など不正な値を入力して Blur した場合、変更が反映されず編集が閉じること
