### PR TITLE
feat(pos): キャッシャーに「お釣り 0」ボタンを追加

### DIFF
--- a/services/pos/app/components/organisms/SubmitSection.tsx
+++ b/services/pos/app/components/organisms/SubmitSection.tsx
@@ -5,11 +5,17 @@ import { Button } from "../ui/button";
 
 type props = {
   submitOrder: () => void;
+  onExactPayment: () => void;
   order: OrderEntity;
   focus: boolean;
 };
 
-export const SubmitSection = ({ submitOrder, order, focus }: props) => {
+export const SubmitSection = ({
+  submitOrder,
+  onExactPayment,
+  order,
+  focus,
+}: props) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const billingOk = useMemo(
     () => order.items.length > 0 && order.getCharge() >= 0,
@@ -46,6 +52,21 @@ export const SubmitSection = ({ submitOrder, order, focus }: props) => {
         </Button>
         <label htmlFor="submit-button" className="text-sm text-stone-400">
           赤枠が出ている状態で Enter で送信
+        </label>
+        <Button
+          id="exact-payment-button"
+          variant="outline"
+          className="h-14 w-40 border-stone-400 font-bold text-lg hover:bg-stone-100 focus-visible:ring-4 focus-visible:ring-stone-400 disabled:border-stone-300 disabled:text-stone-400"
+          onClick={() => onExactPayment()}
+          disabled={order.items.length === 0}
+        >
+          お釣り 0
+        </Button>
+        <label
+          htmlFor="exact-payment-button"
+          className="text-sm text-stone-400"
+        >
+          合計どおり受け取ったとき
         </label>
         {needsSplit && (
           <p className="text-center font-bold text-red-500">

--- a/services/pos/app/components/organisms/SubmitSection.tsx
+++ b/services/pos/app/components/organisms/SubmitSection.tsx
@@ -16,7 +16,8 @@ export const SubmitSection = ({
   order,
   focus,
 }: props) => {
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
+  const exactPaymentButtonRef = useRef<HTMLButtonElement>(null);
   const billingOk = useMemo(
     () => order.items.length > 0 && order.getCharge() >= 0,
     [order],
@@ -32,17 +33,20 @@ export const SubmitSection = ({
    * OK
    */
   useEffect(() => {
-    if (focus) {
-      buttonRef.current?.focus();
+    if (!focus) return;
+    if (billingOk) {
+      submitButtonRef.current?.focus();
+    } else if (order.items.length > 0) {
+      exactPaymentButtonRef.current?.focus();
     }
-  }, [focus]);
+  }, [focus, billingOk, order.items.length]);
 
   return (
     <div className="pt-5">
       <div className="flex flex-col items-center gap-2">
         <Button
           id="submit-button"
-          ref={buttonRef}
+          ref={submitButtonRef}
           className="h-20 w-40 bg-stone-900 font-bold text-2xl hover:bg-pink-700 focus-visible:ring-4 focus-visible:ring-pink-500 disabled:bg-stone-400"
           onClick={() => submitOrder()}
           disabled={!billingOk}
@@ -55,6 +59,7 @@ export const SubmitSection = ({
         </label>
         <Button
           id="exact-payment-button"
+          ref={exactPaymentButtonRef}
           variant="outline"
           className="h-14 w-40 border-stone-400 font-bold text-lg hover:bg-stone-100 focus-visible:ring-4 focus-visible:ring-stone-400 disabled:border-stone-300 disabled:text-stone-400"
           onClick={() => onExactPayment()}

--- a/services/pos/app/components/pages/CashierV2.tsx
+++ b/services/pos/app/components/pages/CashierV2.tsx
@@ -35,6 +35,7 @@ type props = {
   items: WithId<ItemEntity>[] | undefined; // itemMasterを渡す
   orders: WithId<OrderEntity>[] | undefined;
   wsStatus: "connecting" | "open" | "closed" | "error";
+  canSubmitOrder: boolean;
   submitPayload: (order: OrderEntity) => void;
   syncOrder: (order: OrderEntity) => void;
 };
@@ -48,6 +49,7 @@ const CashierV2 = ({
   items,
   orders,
   wsStatus,
+  canSubmitOrder,
   submitPayload,
   syncOrder,
 }: props) => {
@@ -109,8 +111,29 @@ const CashierV2 = ({
     renewUISession();
   }, [newOrderDispatch, resetStatus, renewUISession]);
 
+  const canEnterSubmit = canSubmitOrder && newOrder.items.length > 0;
+
+  const proceedStatusGuarded = useCallback(() => {
+    if (inputStatus === "received" && !canEnterSubmit) {
+      return;
+    }
+    proceedStatus();
+  }, [inputStatus, canEnterSubmit, proceedStatus]);
+
+  /**
+   * FIXME #412 useEffect内でstateを更新している
+   */
+  useEffect(() => {
+    if (inputStatus === "submit" && !canEnterSubmit) {
+      setInputStatus("received");
+    }
+  }, [inputStatus, canEnterSubmit, setInputStatus]);
+
   const submitOrder = useCallback(
     (exactPayment?: boolean) => {
+      if (!canSubmitOrder) {
+        return;
+      }
       if (!exactPayment && newOrder.getCharge() < 0) {
         return;
       }
@@ -138,6 +161,7 @@ const CashierV2 = ({
       playSound();
     },
     [
+      canSubmitOrder,
       newOrder,
       resetAll,
       printer,
@@ -153,13 +177,13 @@ const CashierV2 = ({
 
   const keyEventHandlers = useMemo(() => {
     return {
-      ArrowRight: proceedStatus,
+      ArrowRight: proceedStatusGuarded,
       ArrowLeft: previousStatus,
       Escape: () => {
         resetAll();
       },
     };
-  }, [proceedStatus, previousStatus, resetAll]);
+  }, [proceedStatusGuarded, previousStatus, resetAll]);
 
   /**
    * OK
@@ -340,12 +364,17 @@ const CashierV2 = ({
               focus={inputStatus === "submit"}
               number={5}
             />
-            <SubmitSection
-              submitOrder={submitOrder}
-              onExactPayment={() => submitOrder(true)}
-              order={newOrder}
-              focus={inputStatus === "submit"}
-            />
+            <fieldset
+              disabled={!canEnterSubmit}
+              className="min-w-0 border-0 p-0"
+            >
+              <SubmitSection
+                submitOrder={submitOrder}
+                onExactPayment={() => submitOrder(true)}
+                order={newOrder}
+                focus={inputStatus === "submit"}
+              />
+            </fieldset>
           </div>
         </div>
         <audio src={bellTwice} ref={soundRef}>

--- a/services/pos/app/components/pages/CashierV2.tsx
+++ b/services/pos/app/components/pages/CashierV2.tsx
@@ -109,43 +109,47 @@ const CashierV2 = ({
     renewUISession();
   }, [newOrderDispatch, resetStatus, renewUISession]);
 
-  const submitOrder = useCallback(() => {
-    if (newOrder.getCharge() < 0) {
-      return;
-    }
-    if (newOrder.items.length === 0) {
-      return;
-    }
-    const toteSetProcessedOrder = transformToteSet(newOrder, items ?? []);
-    // 送信する直前に createdAt を更新する
-    const submitOne = toteSetProcessedOrder.clone();
-    submitOne.nowCreated();
-    goodsOnlyServed(submitOne);
-    // 備考を追加
-    submitOne.addComment("cashier", descComment);
-    printer.printOrderLabel(submitOne);
-    submitPayload(submitOne);
+  const submitOrder = useCallback(
+    (exactPayment?: boolean) => {
+      if (!exactPayment && newOrder.getCharge() < 0) {
+        return;
+      }
+      if (newOrder.items.length === 0) {
+        return;
+      }
+      const toteSetProcessedOrder = transformToteSet(newOrder, items ?? []);
+      // 送信する直前に createdAt を更新する
+      const submitOne = toteSetProcessedOrder.clone();
+      if (exactPayment) submitOne.received = submitOne.billingAmount;
+      submitOne.nowCreated();
+      goodsOnlyServed(submitOne);
+      // 備考を追加
+      submitOne.addComment("cashier", descComment);
+      printer.printOrderLabel(submitOne);
+      submitPayload(submitOne);
 
-    // オフライン時（手動番号指定時）は次の番号を自動設定
-    if (manualOrderId !== null && wsStatus !== "open") {
-      setOrderIdOverride(manualOrderId + 1);
-    }
+      // オフライン時（手動番号指定時）は次の番号を自動設定
+      if (manualOrderId !== null && wsStatus !== "open") {
+        setOrderIdOverride(manualOrderId + 1);
+      }
 
-    resetAll();
-    setServiceActive(false);
-    playSound();
-  }, [
-    newOrder,
-    resetAll,
-    printer,
-    submitPayload,
-    descComment,
-    playSound,
-    manualOrderId,
-    setOrderIdOverride,
-    wsStatus,
-    items,
-  ]);
+      resetAll();
+      setServiceActive(false);
+      playSound();
+    },
+    [
+      newOrder,
+      resetAll,
+      printer,
+      submitPayload,
+      descComment,
+      playSound,
+      manualOrderId,
+      setOrderIdOverride,
+      wsStatus,
+      items,
+    ],
+  );
 
   const keyEventHandlers = useMemo(() => {
     return {
@@ -338,6 +342,7 @@ const CashierV2 = ({
             />
             <SubmitSection
               submitOrder={submitOrder}
+              onExactPayment={() => submitOrder(true)}
               order={newOrder}
               focus={inputStatus === "submit"}
             />

--- a/services/pos/app/routes/_header.cashier.tsx
+++ b/services/pos/app/routes/_header.cashier.tsx
@@ -12,6 +12,7 @@ import type { ClientActionFunction, MetaFunction } from "react-router";
 import { z } from "zod";
 import { useAuth } from "~/components/functional/AuthProvider";
 import { useFlaggedSubmit } from "~/components/functional/useFlaggedSubmit";
+import { useOnlineStatus } from "~/components/functional/useOnlineStatus";
 import { CashierV2 } from "~/components/pages/CashierV2";
 import { useOrdersWSContext } from "./context/OrdersWSContext";
 
@@ -25,7 +26,12 @@ export default function Cashier() {
   const disableFirebase = useMemo(() => user == null, [user]);
   const { items } = useItemMaster();
   const { orders, status } = useOrdersWSContext();
+  const isNetworkOnline = useOnlineStatus();
   const submit = useFlaggedSubmit({ disableFirebase });
+  const canSubmitOrder = useMemo(
+    () => user != null && isNetworkOnline && status === "open",
+    [user, isNetworkOnline, status],
+  );
 
   const submitPayload = useCallback(
     (newOrder: OrderEntity) => {
@@ -49,6 +55,7 @@ export default function Cashier() {
       items={items}
       orders={orders}
       wsStatus={status}
+      canSubmitOrder={canSubmitOrder}
       submitPayload={submitPayload}
       syncOrder={syncOrder}
     />


### PR DESCRIPTION
## Summary

- キャッシャー（CashierV2）に「お釣り 0」ボタンを追加し、合計どおり受け取ったときは会計入力を省略して送信できるようにした。
- 送信可能条件を `_header.cashier` で集約（ログイン済み・`navigator.onLine`・注文 WebSocket が `open`）。条件を満たさないときは確定エリアに進めず、入っていた場合は会計に戻す。
- 確定エリアのボタンは `fieldset disabled` で一括無効化し、オフライン時の誤操作を防ぐ。
- 会計ステップでは、金額不足でも商品があれば → で「お釣り 0」にフォーカスが当たるようにした。

Closes #551

## Test plan

- [ ] オンライン・WS 接続時: 商品追加後、会計未入力で「お釣り 0」で送信でき、`received` が合計と一致すること
- [ ] オンライン・受取入力済み: 従来どおり「送信」で送れること
- [ ] オフラインまたは WS 切断時: 会計から → で確定に進めず、確定にいた状態で切断したら会計に戻ること。確定のボタンが押せないこと
- [ ] 商品未選択: 確定に進めず「お釣り 0」も無効であること