### PR TITLE
callscreenリロード時に準備完了済みオーダーが表示されない問題を修正

### DIFF
--- a/modules/common/src/hooks/useOrdersWS.ts
+++ b/modules/common/src/hooks/useOrdersWS.ts
@@ -11,8 +11,13 @@ type WSMessage =
   | { type: "orders"; orders: OrderResponse[] }
   | { type: "master_state"; master_state: MasterState };
 
+// orders 未受信時に返す固定の空配列
+// 毎回リテラルを返すと参照が変わり、依存配列に orders を持つ側が無駄に再実行されるため定数化している
+const EMPTY_ORDERS: WithId<OrderEntity>[] = [];
+
 export const useOrdersWS = () => {
-  const [orders, setOrders] = useState<WithId<OrderEntity>[]>([]);
+  // 「未受信」と「受信したが0件」を区別するため、初期値は undefined
+  const [orders, setOrders] = useState<WithId<OrderEntity>[]>();
   const [masterState, setMasterState] = useState<MasterState | null>(null);
   const [status, setStatus] = useState<WsStatus>("connecting");
 
@@ -59,5 +64,11 @@ export const useOrdersWS = () => {
     };
   }, []);
 
-  return { orders, masterState, status };
+  return {
+    orders: orders ?? EMPTY_ORDERS,
+    /** WebSocket から一度でも orders を受信したか */
+    isOrdersLoaded: orders !== undefined,
+    masterState,
+    status,
+  };
 };

--- a/services/pos/app/routes/callscreen.hooks.tsx
+++ b/services/pos/app/routes/callscreen.hooks.tsx
@@ -33,20 +33,24 @@ function isOrderUnreadyStateChanged(
  * オーダーの状態（準備中 → 提供可能）の変化を監視し、
  * 適切な処理（キュー追加、表示更新など）を実行します。
  */
-export function useOrderState(orders: Order[] | undefined) {
+export function useOrderState(orders: Order[], isOrdersLoaded: boolean) {
   const [queue, setQueue] = useState<number[]>([]);
   const [current, setCurrent] = useState<number | null>(null);
   const [displayedOrders, setDisplayedOrders] = useState<Set<number>>(
     new Set(),
   );
-  const prevOrdersRef = useRef<typeof orders>();
+  const prevOrdersRef = useRef<Order[]>();
+  const initializedRef = useRef(false);
   const animatedRightCardsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
-    if (!orders) return;
+    // 未受信の空配列で初期化してしまうと、リロード前から準備完了だったオーダーが
+    // 表示リストにも「新しく準備完了になったオーダー」にも入らず表示されなくなる
+    if (!isOrdersLoaded) return;
 
     // 初期化処理: 既に準備完了のオーダーを表示リストに追加
-    if (!prevOrdersRef.current) {
+    if (!initializedRef.current) {
+      initializedRef.current = true;
       const existingReadyOrders = orders.filter(
         (order) => order.readyAt !== null && order.servedAt === null,
       );
@@ -77,7 +81,7 @@ export function useOrderState(orders: Order[] | undefined) {
     }
 
     prevOrdersRef.current = orders;
-  }, [orders]);
+  }, [orders, isOrdersLoaded]);
 
   return {
     queue,

--- a/services/pos/app/routes/callscreen.tsx
+++ b/services/pos/app/routes/callscreen.tsx
@@ -21,9 +21,9 @@ export const meta: MetaFunction = () => {
 };
 
 export default function FielsOfCallScreen() {
-  const { orders } = useOrdersWSContext();
+  const { orders, isOrdersLoaded } = useOrdersWSContext();
 
-  const orderState = useOrderState(orders);
+  const orderState = useOrderState(orders, isOrdersLoaded);
   const {
     queue,
     current,
@@ -43,8 +43,6 @@ export default function FielsOfCallScreen() {
   const soundRef = useRef<HTMLAudioElement>(null);
 
   const callingOrders = useMemo(() => {
-    if (!orders) return [];
-
     return orders
       .filter((order) => {
         if (order.servedAt !== null) return false;
@@ -164,7 +162,7 @@ export default function FielsOfCallScreen() {
           />
         </h1>
         <div className="grid grid-cols-8 gap-2">
-          {orders?.map(
+          {orders.map(
             (order) =>
               order.servedAt === null &&
               order.readyAt === null && (

--- a/services/pos/app/routes/context/OrdersWSContext.tsx
+++ b/services/pos/app/routes/context/OrdersWSContext.tsx
@@ -1,13 +1,8 @@
-import { type OrderEntity, type WithId, useOrdersWS } from "@cafeore/common";
+import { useOrdersWS } from "@cafeore/common";
 // context/OrdersWSContext.tsx
 import { createContext, useContext } from "react";
 
-type WsStatus = "connecting" | "open" | "closed" | "error";
-
-type OrdersWSContextValue = {
-  orders: WithId<OrderEntity>[];
-  status: WsStatus;
-};
+type OrdersWSContextValue = ReturnType<typeof useOrdersWS>;
 
 const OrdersWSContext = createContext<OrdersWSContextValue | null>(null);
 


### PR DESCRIPTION
close #677

## 問題

`useOrdersWS` の `orders` 初期値が `[]` だったため、WebSocket でデータが届く前に `useOrderState` の初期化処理が空配列で走ってしまっていた。その後実データが届いても `prevOrdersRef.current` がセット済みなので初期化はスキップされ、新規追加の検出ロジックに入る。リロード前から準備完了だったオーダーは「新しく準備完了になった」とは判定されないため、`displayedOrders` に入らず画面に出てこない。

## 対応

初期値を `undefined` にすると利用側全部で `orders ?? []` を書くことになってダサいので、「未受信」と「受信したが0件」の区別はフック内部に閉じ込めて、外向きの `orders` は常に配列のままにした。

- `useOrdersWS` の内部 state 初期値を `undefined` に変更し、返り値は `orders ?? EMPTY_ORDERS` にフォールバック
  - `EMPTY_ORDERS` はモジュールレベルの定数。ここでリテラル `[]` を返すと毎レンダーで参照が変わり、`orders` を依存配列に持つ `useEffect` / `useMemo` が無駄に再実行されてしまうため
  - 受信済みかどうかは `isOrdersLoaded` で公開
- `useOrderState` は初期化判定を専用の `initializedRef` に分離し、`isOrdersLoaded` が true になるまで（＝最初の実データが届くまで）初期化を走らせないようにした
- `OrdersWSContext` の手書き型定義を `ReturnType<typeof useOrdersWS>` に置き換え。今回のように返り値が増えても追従漏れが起きない
- `orders` が非 nullable のままなので、`callscreen.tsx` の死んだ `if (!orders) return []` と `orders?.map` を整理

`orders` の型は `WithId<OrderEntity>[]` のままなので、issue に書かれていた TS18048 は出ず、他の consumer（master / dashboard / serve / orders）は無変更で通る。

## レビュワーへ

- `pnpm pos typecheck` パス（issue に挙がっていた CI エラーはこれ）
- `pnpm common typecheck` はエラー182件だが変更前後で同数。すべて node_modules の `@types/react` 重複宣言による既存エラーで、ソース側は0件
- `biome check` は変更4ファイルクリーン
- `pnpm common test:unit` 16 passed
- 実機でリロードして準備完了オーダーが「お呼び出し中」に残るかの動作確認はしていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)