### PR TITLE
cashierstateをcashier画面から直接出すようにした

### DIFF
--- a/modules/common/src/firebase-utils/converter.ts
+++ b/modules/common/src/firebase-utils/converter.ts
@@ -8,12 +8,7 @@ import {
 import _ from "lodash";
 import type { ZodSchema } from "zod";
 import type { WithId } from "../lib/typeguard";
-import {
-  CashierStateEntity,
-  MasterStateEntity,
-  globalCashierStateSchema,
-  globalMasterStateSchema,
-} from "../models/global";
+import { MasterStateEntity, globalMasterStateSchema } from "../models/global";
 import { type Item, ItemEntity } from "../models/item";
 import {
   type Order,
@@ -140,22 +135,6 @@ export const orderConverter: FirestoreDataConverter<WithId<OrderEntity>> = {
     return OrderEntity.fromOrder(convertedData);
   },
 };
-
-export const cashierStateConverter: FirestoreDataConverter<CashierStateEntity> =
-  {
-    toFirestore: converter(globalCashierStateSchema).toFirestore,
-    fromFirestore: (
-      snapshot: QueryDocumentSnapshot,
-      options: SnapshotOptions,
-    ) => {
-      const convertedData = converter(globalCashierStateSchema).fromFirestore(
-        snapshot,
-        options,
-      );
-
-      return CashierStateEntity.fromCashierState(convertedData);
-    },
-  };
 
 export const masterStateConverter: FirestoreDataConverter<MasterStateEntity> = {
   toFirestore: converter(globalMasterStateSchema).toFirestore,

--- a/modules/common/src/models/global.ts
+++ b/modules/common/src/models/global.ts
@@ -1,29 +1,4 @@
 import { z } from "zod";
-import { OrderEntity, orderSchema } from "./order";
-
-export const globalCashierStateSchema = z.object({
-  id: z.literal("cashier-state"),
-  edittingOrder: orderSchema,
-  submittedOrderId: z.string().nullable(),
-});
-
-export type GlobalCashierState = z.infer<typeof globalCashierStateSchema>;
-
-export class CashierStateEntity implements GlobalCashierState {
-  constructor(
-    public id: "cashier-state",
-    public edittingOrder: OrderEntity,
-    public submittedOrderId: string | null,
-  ) {}
-
-  static fromCashierState(state: GlobalCashierState): CashierStateEntity {
-    return new CashierStateEntity(
-      state.id,
-      OrderEntity.fromOrder(state.edittingOrder),
-      state.submittedOrderId,
-    );
-  }
-}
 
 export const orderStatTypes = ["stop", "operational"] as const;
 
@@ -41,13 +16,6 @@ export const globalMasterStateSchema = z.object({
 });
 
 export type GlobalMasterState = z.infer<typeof globalMasterStateSchema>;
-
-export const globalStatSchema = z.union([
-  globalCashierStateSchema,
-  globalMasterStateSchema,
-]);
-
-export type GlobalStat = z.infer<typeof globalStatSchema>;
 
 export class MasterStateEntity implements GlobalMasterState {
   constructor(

--- a/modules/common/src/repositories/global.ts
+++ b/modules/common/src/repositories/global.ts
@@ -1,40 +1,11 @@
 import { type Firestore, doc, getDoc, setDoc } from "firebase/firestore";
-import {
-  cashierStateConverter,
-  masterStateConverter,
-} from "../firebase-utils/converter";
+import { masterStateConverter } from "../firebase-utils/converter";
 import { prodDB } from "../firebase-utils/firebase";
-import type { GlobalCashierState, MasterStateEntity } from "../models/global";
-
-export type CashierStateRepo = {
-  get: () => Promise<GlobalCashierState | undefined>;
-  set: (state: GlobalCashierState) => Promise<void>;
-};
+import type { MasterStateEntity } from "../models/global";
 
 export type MasterStateRepo = {
   get: () => Promise<MasterStateEntity | undefined>;
   set: (state: MasterStateEntity) => Promise<void>;
-};
-
-export const cashierStateRepoFactory = (db: Firestore): CashierStateRepo => {
-  return {
-    get: async () => {
-      const docRef = doc(db, "global", "cashier-state").withConverter(
-        cashierStateConverter,
-      );
-      const docSnap = await getDoc(docRef);
-      const data = docSnap.data();
-      if (data?.id === "cashier-state") {
-        return data;
-      }
-    },
-    set: async (state) => {
-      const docRef = doc(db, "global", "cashier-state").withConverter(
-        cashierStateConverter,
-      );
-      await setDoc(docRef, state);
-    },
-  };
 };
 
 export const masterStateRepoFactory = (db: Firestore): MasterStateRepo => {
@@ -58,5 +29,4 @@ export const masterStateRepoFactory = (db: Firestore): MasterStateRepo => {
   };
 };
 
-export const cashierRepository = cashierStateRepoFactory(prodDB);
 export const masterRepository = masterStateRepoFactory(prodDB);

--- a/services/pos/app/components/functional/useCashierDisplay.ts
+++ b/services/pos/app/components/functional/useCashierDisplay.ts
@@ -1,0 +1,52 @@
+import { OrderEntity } from "@cafeore/common";
+import { useEffect, useMemo, useState } from "react";
+import {
+  type CashierDisplayMessage,
+  type CashierDisplayState,
+  openCashierDisplayChannel,
+} from "~/lib/cashierDisplay";
+
+export type CashierDisplay = {
+  edittingOrder: OrderEntity;
+  submittedOrder: OrderEntity | null;
+};
+
+/**
+ * レジ画面 (/cashier) が配信している表示内容を受け取るフック
+ *
+ * 同じブラウザでレジ画面が開かれていない間は null を返す
+ * @returns 表示内容
+ */
+export const useCashierDisplay = (): CashierDisplay | null => {
+  const [state, setState] = useState<CashierDisplayState | null>(null);
+
+  /**
+   * OK
+   */
+  useEffect(() => {
+    const channel = openCashierDisplayChannel();
+    channel.onmessage = (event: MessageEvent<CashierDisplayMessage>) => {
+      if (event.data.type === "publish") {
+        setState(event.data.state);
+      }
+    };
+    // 画面を開いた直後は配信を受け取れていないため、レジ画面に現在の状態を要求する
+    channel.postMessage({ type: "request" } satisfies CashierDisplayMessage);
+    return () => {
+      channel.close();
+    };
+  }, []);
+
+  return useMemo(() => {
+    if (state == null) {
+      return null;
+    }
+    return {
+      edittingOrder: OrderEntity.fromOrder(state.edittingOrder),
+      submittedOrder:
+        state.submittedOrder == null
+          ? null
+          : OrderEntity.fromOrder(state.submittedOrder),
+    };
+  }, [state]);
+};

--- a/services/pos/app/components/functional/usePublishCashierDisplay.ts
+++ b/services/pos/app/components/functional/usePublishCashierDisplay.ts
@@ -1,0 +1,81 @@
+import type { OrderEntity } from "@cafeore/common";
+import { useCallback, useEffect, useRef } from "react";
+import {
+  type CashierDisplayMessage,
+  type CashierDisplayState,
+  openCashierDisplayChannel,
+} from "~/lib/cashierDisplay";
+
+const postState = (channel: BroadcastChannel, state: CashierDisplayState) => {
+  channel.postMessage({
+    type: "publish",
+    state,
+  } satisfies CashierDisplayMessage);
+};
+
+/**
+ * 客用画面 (/cashier-mini) に表示する内容を配信するフック
+ *
+ * Entity はメソッドを持ち構造化複製できないため、Order に変換してから送る
+ */
+export const usePublishCashierDisplay = () => {
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const stateRef = useRef<CashierDisplayState | null>(null);
+
+  const publish = useCallback((state: CashierDisplayState) => {
+    stateRef.current = state;
+    const channel = channelRef.current;
+    if (channel != null) {
+      postState(channel, state);
+    }
+  }, []);
+
+  /**
+   * OK
+   */
+  useEffect(() => {
+    const channel = openCashierDisplayChannel();
+    channelRef.current = channel;
+    channel.onmessage = (event: MessageEvent<CashierDisplayMessage>) => {
+      // 客用画面を開き直したときのために、要求されたら最新の状態を送り直す
+      const state = stateRef.current;
+      if (event.data.type === "request" && state != null) {
+        postState(channel, state);
+      }
+    };
+    // 子コンポーネントの effect が先に実行されるため、
+    // チャンネルの開通前に配信された状態を取りこぼしうる
+    if (stateRef.current != null) {
+      postState(channel, stateRef.current);
+    }
+    return () => {
+      channelRef.current = null;
+      channel.close();
+    };
+  }, []);
+
+  const publishEdittingOrder = useCallback(
+    (order: OrderEntity) => {
+      // オーダーの確定直後はリセットされた空のオーダーが流れてくるが、
+      // それによって確定済みの表示を消さないようにする
+      if (
+        stateRef.current?.submittedOrder != null &&
+        order.items.length === 0
+      ) {
+        return;
+      }
+      publish({ edittingOrder: order.toOrder(), submittedOrder: null });
+    },
+    [publish],
+  );
+
+  const publishSubmittedOrder = useCallback(
+    (order: OrderEntity) => {
+      const submittedOrder = order.toOrder();
+      publish({ edittingOrder: submittedOrder, submittedOrder });
+    },
+    [publish],
+  );
+
+  return { publishEdittingOrder, publishSubmittedOrder };
+};

--- a/services/pos/app/lib/cashierDisplay.ts
+++ b/services/pos/app/lib/cashierDisplay.ts
@@ -1,0 +1,26 @@
+import type { Order } from "@cafeore/common";
+
+/**
+ * レジ画面 (/cashier) から客用画面 (/cashier-mini) へ表示内容を配信するチャンネル
+ *
+ * BroadcastChannel は同一ブラウザの同一オリジン間でしか届かないため、
+ * 客用画面はレジのパソコンにつないだモニタで開く必要がある
+ */
+const CHANNEL_NAME = "cafeore-cashier-display";
+
+/** 客用画面に表示する内容 */
+export type CashierDisplayState = {
+  /** レジで入力中のオーダー */
+  edittingOrder: Order;
+  /** 確定したオーダー 入力中は null */
+  submittedOrder: Order | null;
+};
+
+export type CashierDisplayMessage =
+  /** レジ画面が表示内容を配信する */
+  | { type: "publish"; state: CashierDisplayState }
+  /** 客用画面が最新の表示内容を要求する（画面を開いた直後） */
+  | { type: "request" };
+
+export const openCashierDisplayChannel = () =>
+  new BroadcastChannel(CHANNEL_NAME);

--- a/services/pos/app/routes/_header.cashier.tsx
+++ b/services/pos/app/routes/_header.cashier.tsx
@@ -1,6 +1,5 @@
 import {
   OrderEntity,
-  cashierRepository,
   orderRepository,
   orderSchema,
   stringToJSONSchema,
@@ -12,6 +11,7 @@ import type { ClientActionFunction, MetaFunction } from "react-router";
 import { z } from "zod";
 import { useAuth } from "~/components/functional/AuthProvider";
 import { useFlaggedSubmit } from "~/components/functional/useFlaggedSubmit";
+import { usePublishCashierDisplay } from "~/components/functional/usePublishCashierDisplay";
 import { CashierV2 } from "~/components/pages/CashierV2";
 import { useOrdersWSContext } from "./context/OrdersWSContext";
 
@@ -26,22 +26,19 @@ export default function Cashier() {
   const { items } = useItemMaster();
   const { orders, status } = useOrdersWSContext();
   const submit = useFlaggedSubmit({ disableFirebase });
+  // 客用画面へは同じパソコンのウィンドウに直接配信する
+  const { publishEdittingOrder, publishSubmittedOrder } =
+    usePublishCashierDisplay();
 
   const submitPayload = useCallback(
     (newOrder: OrderEntity) => {
+      publishSubmittedOrder(newOrder);
       submit(
         { newOrder: JSON.stringify(newOrder.toOrder()) },
         { method: "POST" },
       );
     },
-    [submit],
-  );
-
-  const syncOrder = useCallback(
-    (order: OrderEntity) => {
-      submit({ syncOrder: JSON.stringify(order.toOrder()) }, { method: "PUT" });
-    },
-    [submit],
+    [submit, publishSubmittedOrder],
   );
 
   return (
@@ -50,22 +47,17 @@ export default function Cashier() {
       orders={orders}
       wsStatus={status}
       submitPayload={submitPayload}
-      syncOrder={syncOrder}
+      syncOrder={publishEdittingOrder}
     />
   );
 }
 
 // TODO(toririm): リファクタリングするときにファイルを切り出す
 export const clientAction: ClientActionFunction = async (args) => {
-  const method = args.request.method;
-  switch (method) {
-    case "POST":
-      return submitOrderAction(args);
-    case "PUT":
-      return syncOrderAction(args);
-    default:
-      return new Response("Method not allowed", { status: 405 });
+  if (args.request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
   }
+  return submitOrderAction(args);
 };
 
 export const submitOrderAction: ClientActionFunction = async ({ request }) => {
@@ -85,41 +77,7 @@ export const submitOrderAction: ClientActionFunction = async ({ request }) => {
   const { newOrder } = submission.value;
   const order = OrderEntity.fromOrder(newOrder);
 
-  const savedOrder = await orderRepository.save(order);
-
-  const cashierState = await cashierRepository.get();
-  if (cashierState == null) {
-    return console.log("cashierState is null");
-  }
-  await cashierRepository.set({
-    ...cashierState,
-    submittedOrderId: savedOrder.id,
-  });
-
-  return new Response("ok");
-};
-
-export const syncOrderAction: ClientActionFunction = async ({ request }) => {
-  const formData = await request.formData();
-
-  const schema = z.object({
-    syncOrder: stringToJSONSchema.pipe(orderSchema),
-  });
-  const submission = parseWithZod(formData, {
-    schema,
-  });
-  if (submission.status !== "success") {
-    console.error(submission.error);
-    return submission.reply();
-  }
-
-  const { syncOrder } = submission.value;
-
-  cashierRepository.set({
-    id: "cashier-state",
-    edittingOrder: OrderEntity.fromOrder(syncOrder),
-    submittedOrderId: null,
-  });
+  await orderRepository.save(order);
 
   return new Response("ok");
 };

--- a/services/pos/app/routes/cashier-mini.tsx
+++ b/services/pos/app/routes/cashier-mini.tsx
@@ -1,13 +1,8 @@
-import {
-  cashierStateConverter,
-  documentSub,
-  orderConverter,
-} from "@cafeore/common";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { MetaFunction } from "react-router";
-import useSWRSubscription from "swr/subscription";
 import logoSVG from "~/assets/cafeore.svg";
 import logoMotion from "~/assets/cafeore_logo_motion.webm";
+import { useCashierDisplay } from "~/components/functional/useCashierDisplay";
 import { useOrderStat } from "~/components/functional/useOrderStat";
 import { cn } from "~/lib/utils";
 
@@ -20,32 +15,28 @@ export default function CasherMini() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const soundRef1 = useRef<HTMLAudioElement>(null);
   const soundRef2 = useRef<HTMLAudioElement>(null);
-  const { data: orderState } = useSWRSubscription(
-    ["global", "cashier-state"],
-    documentSub({ converter: cashierStateConverter }),
-  );
-  const order = orderState?.edittingOrder;
-  const submittedOrderId = orderState?.submittedOrderId;
-  const { data: preOrder } = useSWRSubscription(
-    ["orders", submittedOrderId ?? "none"],
-    documentSub({ converter: orderConverter }),
-  );
+  // レジ画面 (/cashier) から同じパソコン内で配信されてくる
+  const display = useCashierDisplay();
+  const order = display?.edittingOrder;
+  const submittedOrder = display?.submittedOrder ?? null;
+  const submittedOrderId = submittedOrder?.orderId ?? null;
   const isOperational = useOrderStat();
 
   const orderId = useMemo(() => {
     if (logoShown) {
-      return preOrder?.orderId;
+      return submittedOrder?.orderId;
     }
     return order?.orderId;
-  }, [order, logoShown, preOrder]);
+  }, [order, logoShown, submittedOrder]);
 
   /**
    * FIXME #412 useEffect内でstateを更新している
    * https://ja.react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes
    */
   useEffect(() => {
-    setLogoShown(submittedOrderId != null || !isOperational);
-  }, [submittedOrderId, isOperational]);
+    // レジ画面が開かれていない間 (display == null) はロゴを出しておく
+    setLogoShown(display == null || submittedOrderId != null || !isOperational);
+  }, [display, submittedOrderId, isOperational]);
 
   /**
    * OK
@@ -61,7 +52,7 @@ export default function CasherMini() {
    * OK
    */
   useEffect(() => {
-    if (submittedOrderId === null) {
+    if (submittedOrderId == null) {
       return;
     }
     soundRef1.current?.play();


### PR DESCRIPTION
close #684

レジ画面 (`/cashier`) の入力を Firestore の `global/cashier-state` 経由で客用画面 (`/cashier-mini`) に渡していたのをやめ、BroadcastChannel で同じパソコンの別ウィンドウへ直接配信するようにしました。客用画面はレジのパソコンに有線でつないだモニタに出す想定です。

## 変更点

新規
- `app/lib/cashierDisplay.ts` チャンネル名とメッセージ型 (`publish` / `request`)
- `app/components/functional/usePublishCashierDisplay.ts` レジ側の配信
- `app/components/functional/useCashierDisplay.ts` 客用画面側の受信

変更
- `_header.cashier.tsx` `syncOrderAction` (PUT) と `cashierRepository` への書き込みを削除し、チャンネル配信に差し替え
- `cashier-mini.tsx` Firestore の購読2本を削除してチャンネル受信に
- `modules/common` 使われなくなった `cashierRepository` / `CashierStateEntity` / `cashierStateConverter` / `globalCashierStateSchema` / `globalStatSchema` を削除

## 設計

- Entity はメソッドを持ち構造化複製できないため、`toOrder()` した `Order` を送って受信側で `OrderEntity.fromOrder()` している
- 客用画面はマウント時に `request` を投げ、レジ側が最新状態を返す。どちらを先に開いても、また客用画面をリロードしても表示が復帰する
- オーダー確定直後はレジがリセットされて空のオーダーが流れてくるが、確定表示中は空のオーダーを無視するので「ご注文ありがとうございました」が即座に消えない。次の商品を入力した時点で切り替わる
- レジ画面が開かれていない間 (`display == null`) はロゴを出す。これまでは空の伝票が表示されていた

## レビューしてほしいところ・注意点

- 客用画面は**レジと同じパソコンの同じブラウザ**で開く必要があります。別マシンでの `/cashier-mini` は動かなくなります
- オーダーストップ表示だけは引き続き Firestore の `master-state` を見ています（マスター画面が別マシンのため）
- Firestore の `global/cashier-state` ドキュメントは未使用になります
- 副次的に、未ログイン状態でも客用画面が動くようになりました（Firestore への書き込みが不要になったため）

## 動作確認

- `pnpm pos typecheck` / `pnpm common test:unit` は通過。`pnpm common typecheck` のエラーは `@types/react` の重複由来で main と同数（src 由来は 0 件）
- dev サーバで `/cashier-mini` を確認：入力の反映（合計・お預かり・おつりが正しく再計算される）、確定画面への遷移、別ウィンドウがある状態でのリロード復帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)